### PR TITLE
Added difference between through the year and last fiscal year stats

### DIFF
--- a/src/components/stats/gdp-annual.html
+++ b/src/components/stats/gdp-annual.html
@@ -1,7 +1,9 @@
 <h3>GDP Annual Change:</h3>
 <ul>
-    <li>GDP:</li>
+    <li>GDP Through the Year:</li>
     <p class="list">1.8%</p>
+    <li>GDP Last Fiscal Year</li>
+    <p class="list">1.3%</p>
     <li>Per Capita:</li>
     <p class="list">0.2%</p>
     <li>Per Hour Worked:</li>


### PR DESCRIPTION
There was some confusion around two stats on the ABS website, one saying that GDP rose 1.3% from 2024-2025, and the other saying 1.8%. The difference is that the 1.8% is through the year, so June 2024 to June 2025, not July 1st 2024 to June 31st 2025. Both stats have been added, as well as clarification through labelling them differently.