### PR TITLE
Added tracking code to all the different pages

### DIFF
--- a/definitions.html
+++ b/definitions.html
@@ -4,6 +4,7 @@
         <title>Important Economics Statistics</title>
         <link rel="stylesheet" href="src/main.css">
         <link rel="icon" href="assets/TDEC-J-icon.png" type="image/png">
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="5b661559-a95d-444d-b6ca-932efc8875f5"></script>
     </head>
     <body>
         <div id="navbar"></div>

--- a/graphs.html
+++ b/graphs.html
@@ -4,6 +4,7 @@
         <title>Corrosponding Graphs</title>
         <link rel="stylesheet" href="src/main.css">
         <link rel="icon" href="assets/TDEC-J-icon.png" type="image/png">
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="5b661559-a95d-444d-b6ca-932efc8875f5"></script>
     </head>
     <body>
         <div id="navbar"></div>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
         <title>Economic Statistics</title>
         <link rel="stylesheet" href="src/main.css">
         <link rel="icon" href="assets/TDEC-J-icon.png" type="image/png">
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="5b661559-a95d-444d-b6ca-932efc8875f5"></script>
     </head>
     <body>
         <div id="navbar"></div>

--- a/stats.html
+++ b/stats.html
@@ -4,6 +4,7 @@
         <title>Important Economics Statistics</title>
         <link rel="stylesheet" href="src/main.css">
         <link rel="icon" href="assets/TDEC-J-icon.png" type="image/png">
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="5b661559-a95d-444d-b6ca-932efc8875f5"></script>
     </head>
     <body>
         <div id="navbar"></div>


### PR DESCRIPTION
Adding a Umami traffic tracking code snippet to the `<head></head>` sections of all of the major pages as github pages shows repo traffic, not site traffic.